### PR TITLE
Remove chat deletion confirmation

### DIFF
--- a/content.js
+++ b/content.js
@@ -1597,16 +1597,7 @@ openA.addEventListener("click", (e) => {
 
 
   // deletion
-li.querySelector('[data-act="del"]').addEventListener("click", async () => {
-  const ok = await openConfirmDialog({
-    title: "Delete chat",
-    message: `Delete “${(item && (item.text || item.title)) || "Untitled"}”?`,
-    confirmText: "Delete",
-    cancelText: "Cancel",
-    danger: true
-  });
-  if (!ok) return;
-
+  li.querySelector('[data-act="del"]').addEventListener("click", async () => {
   const trueFullIdx = idxFromFiltered(visible, s.folders[folderName], q, idxVis);
   s.folders[folderName].splice(trueFullIdx, 1);
   await setState(s);


### PR DESCRIPTION
## Summary
- Delete chat immediately without showing confirmation dialog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a18048548330b053c2c7553003e9