### PR TITLE
Avoid highlighting active chat and flag current chat in groups

### DIFF
--- a/panel.css
+++ b/panel.css
@@ -170,6 +170,9 @@
   cursor: grab;
   padding: 8px;
 }
+.req.current {
+  border: 2px dashed var(--border, #ffffff) !important;
+}
 .req.dragging {
   opacity: 0.6;
 }
@@ -202,6 +205,18 @@
   display: inline-block;
   text-align: center;
   line-height: 1.2;
+}
+.current-label {
+  padding: 4px 8px;
+  min-width: 72px;
+  font-size: 11px;
+  border-radius: 10px;
+  background: var(--surface, #1b1b1b);
+  color: var(--text, #fff);
+  border: 1px solid var(--border, #fff);
+  text-align: center;
+  line-height: 1.2;
+  display: inline-block;
 }
 .date {
   font-size: 9px; /* requirement */


### PR DESCRIPTION
## Summary
- Stop coloring active sidebar chat links green
- Replace "Open chat" button with "Current" label for the active chat in groups and highlight its border

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa274fa10c8330b98c111ab2385635