### PR TITLE
feat: rename clear button to delete all

### DIFF
--- a/content.js
+++ b/content.js
@@ -1497,12 +1497,12 @@
     }
   });
 
-  // Clear all
+  // Delete all
   panel.querySelector("#clearBtn").addEventListener("click", async () => {
     const ok = await openConfirmDialog({
-      title: "Clear everything",
+      title: "Delete everything",
       message: "Delete all groups and chats? This cannot be undone.",
-      confirmText: "Clear all",
+      confirmText: "Delete All",
       cancelText: "Cancel",
       danger: true,
     });

--- a/panel.css
+++ b/panel.css
@@ -273,6 +273,12 @@ label.like-button:hover {
   min-width: 110px;
 }
 
+.footer #clearBtn {
+  background: #8a2d2d;
+  border: 1px solid var(--border, #fff);
+  color: #fff;
+}
+
 .drop-target {
   outline: 2px dashed var(--accent, #ffffff);
   outline-offset: 2px;

--- a/panel.html
+++ b/panel.html
@@ -24,5 +24,5 @@
       style="display: none"
     />
   </label>
-  <button id="clearBtn">Clear all</button>
+  <button id="clearBtn">Delete All</button>
 </div>


### PR DESCRIPTION
## Summary
- change footer's Clear all button label to Delete All and style it red
- update delete-all confirmation dialog text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa38b0057483308c75dc30c40c1d4a