### PR TITLE
fix: retain group name focus on Claude

### DIFF
--- a/content.js
+++ b/content.js
@@ -735,6 +735,17 @@
   document.documentElement.appendChild(rootContainer);
   const shadow = rootContainer.attachShadow({ mode: "open" });
 
+  function trapKey(e) {
+    if (rootContainer.contains(e.target)) {
+      e.stopPropagation();
+      const t = e.target;
+      if (t && typeof t.focus === "function") t.focus();
+    }
+  }
+  ["keydown", "keypress", "keyup"].forEach((evt) =>
+    document.addEventListener(evt, trapKey, true),
+  );
+
   const wrap = document.createElement("div");
   shadow.appendChild(wrap);
 


### PR DESCRIPTION
## Summary
- prevent host page from stealing focus when typing in group dialogs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3a367548833095f0e65dae8a9cc6