### PR TITLE
Limit GitHub support to Copilot pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,32 +6,32 @@
   "icons": { "128": "icons/icon128.png" },
   "permissions": ["storage"],
   "host_permissions": [
-    "https://chatgpt.com/*",
-    "https://claude.ai/*",
-    "https://*.perplexity.ai/*",
+      "https://chatgpt.com/*",
+      "https://claude.ai/*",
+      "https://*.perplexity.ai/*",
       "https://github.com/copilot/*"
-  ],
-  "content_scripts": [
-    {
-      "matches": [
-        "https://chatgpt.com/*",
-        "https://claude.ai/*",
-        "https://*.perplexity.ai/*",
-        "https://github.com/copilot/*"
-      ],
-      "js": ["content.js"],
-      "run_at": "document_idle"
-    }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": ["panel.html", "panel.css", "icons/icon128.png"],
-      "matches": [
-        "https://chatgpt.com/*",
-        "https://claude.ai/*",
-        "https://*.perplexity.ai/*",
-        "https://github.com/copilot/*"
-      ]
-    }
-  ]
-}
+    ],
+    "content_scripts": [
+      {
+        "matches": [
+          "https://chatgpt.com/*",
+          "https://claude.ai/*",
+          "https://*.perplexity.ai/*",
+          "https://github.com/copilot/*"
+        ],
+        "js": ["content.js"],
+        "run_at": "document_idle"
+      }
+    ],
+    "web_accessible_resources": [
+      {
+        "resources": ["panel.html", "panel.css", "icons/icon128.png"],
+        "matches": [
+          "https://chatgpt.com/*",
+          "https://claude.ai/*",
+          "https://*.perplexity.ai/*",
+          "https://github.com/*"
+        ]
+      }
+    ]
+  }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "https://chatgpt.com/*",
     "https://claude.ai/*",
     "https://*.perplexity.ai/*",
-    "https://github.com/copilot*"
+      "https://github.com/copilot/*"
   ],
   "content_scripts": [
     {
@@ -17,7 +17,7 @@
         "https://chatgpt.com/*",
         "https://claude.ai/*",
         "https://*.perplexity.ai/*",
-        "https://github.com/copilot*"
+        "https://github.com/copilot/*"
       ],
       "js": ["content.js"],
       "run_at": "document_idle"
@@ -30,7 +30,7 @@
         "https://chatgpt.com/*",
         "https://claude.ai/*",
         "https://*.perplexity.ai/*",
-        "https://github.com/copilot*"
+        "https://github.com/copilot/*"
       ]
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "https://chatgpt.com/*",
     "https://claude.ai/*",
     "https://*.perplexity.ai/*",
-    "https://github.com/*"
+    "https://github.com/copilot*"
   ],
   "content_scripts": [
     {
@@ -17,7 +17,7 @@
         "https://chatgpt.com/*",
         "https://claude.ai/*",
         "https://*.perplexity.ai/*",
-        "https://github.com/*"
+        "https://github.com/copilot*"
       ],
       "js": ["content.js"],
       "run_at": "document_idle"
@@ -30,7 +30,7 @@
         "https://chatgpt.com/*",
         "https://claude.ai/*",
         "https://*.perplexity.ai/*",
-        "https://github.com/*"
+        "https://github.com/copilot*"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Restrict extension's GitHub permissions and script matches to Copilot pages only

## Testing
- `node --check content.js`
- `python -m json.tool manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_68b00486a6b48330804847eb283ddffc